### PR TITLE
move back to original wkhtmltopdf to fix portfolio-report regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yum install yarn -y
 
 # install wkhtmltopdf
 WORKDIR /tmp
-RUN curl -L -O https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox-0.12.5-1.centos6.x86_64.rpm
-RUN yum --nogpgcheck localinstall wkhtmltox-0.12.5-1.centos6.x86_64.rpm -y
+RUN curl -L -O https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-centos6-amd64.rpm
+RUN yum --nogpgcheck localinstall wkhtmltox-0.12.2.1_linux-centos6-amd64.rpm -y
 
 WORKDIR /root


### PR DESCRIPTION
Everything works in OSX, but newer versions of wkhtmltopdf segfault in linux when we try to render html that uses Chart.js v2.5. Chart.js v2.7.2 doesn't segfault, but it also doesn't render the damn charts. So, roll back to the older wkhtmltopdf until I can figure out what's going on.