### PR TITLE
install yarn via npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM lambci/lambda:build-nodejs8.10
 RUN touch /root/.bashrc
 
 # install yarn
-RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
-RUN yum install yarn -y
+RUN npm i -g yarn
 
 # install wkhtmltopdf
 WORKDIR /tmp


### PR DESCRIPTION
because `nodejs` wasn't installed via `yum` so `yum` won't install `yarn` because `yum` doesn't know that `nodejs` is installed